### PR TITLE
Add shuffle API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 .vscode
 **/*.html
+.idea

--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -1,0 +1,173 @@
+use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::circuit::{Cell, Chip, Layouter, Region, SimpleFloorPlanner};
+use halo2_proofs::dev::MockProver;
+use halo2_proofs::plonk::*;
+use pairing::bn256::Fr as Fp;
+use pairing::bn256::{Bn256, G1Affine};
+
+use std::marker::PhantomData;
+
+use halo2_proofs::poly::{
+    commitment::{Params, ParamsVerifier},
+    Rotation,
+};
+use halo2_proofs::transcript::{Blake2bRead, Blake2bWrite, Challenge255};
+use rand_core::OsRng;
+
+#[derive(Clone)]
+struct MyConfig {
+    input: Column<Advice>,
+    shuffle: Column<Advice>,
+    input_q: Column<Advice>,
+    s: Column<Fixed>,
+}
+
+/// The full circuit implementation.
+///
+/// In this struct we store the private input variables. We use `Option<F>` because
+/// they won't have any value during key generation. During proving, if any of these
+/// were `None` we would get an error.
+#[derive(Default, Clone, Debug)]
+struct MyCircuit<F: FieldExt> {
+    _a: PhantomData<F>,
+}
+
+impl<F: FieldExt> MyCircuit<F> {
+    fn construct() -> Self {
+        return Self { _a: PhantomData };
+    }
+}
+
+impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
+    // Since we are using a single chip for everything, we can just reuse its config.
+    type Config = MyConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        // We create the two advice columns that FieldChip uses for I/O.
+        let advice = [
+            meta.advice_column(),
+            meta.advice_column(),
+            meta.advice_column(),
+        ];
+        let select = meta.fixed_column();
+
+        meta.shuffle("shuffle1", |cell| {
+            let exp_a = cell.query_advice(advice[0], Rotation::cur());
+            let exp_b = cell.query_advice(advice[1], Rotation::cur());
+            let q = cell.query_fixed(select, Rotation::cur());
+            let exp_c = cell.query_advice(advice[2], Rotation::cur());
+            // vec![(exp_a, exp_b),(exp_c,q)]
+            vec![(q * exp_a, exp_b)]
+            // vec![(exp_a, exp_b)]
+        });
+
+        Self::Config {
+            input: advice[0],
+            shuffle: advice[1],
+            input_q: advice[2],
+            s: select,
+        }
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        // layouter.enabled()
+        layouter.assign_region(
+            || "sys",
+            |mut region: Region<'_, F>| {
+                for i in 0..2 {
+                    // region.enable_selector(||"sel",&config.s,i);
+                    // config.s.enable(&mut region, i);
+                    // region.assign_fixed(||"",config.s,i,||Ok(F::from(1).into()))?;
+                    // region.assign_advice(||"",config.input_q,i,||Ok(F::from((i as u64+1) *10).into()))?;
+                    region.assign_advice(
+                        || "input",
+                        config.input,
+                        i,
+                        || Ok(F::from((i as u64 + 1)).into()),
+                    )?;
+                    // region.assign_advice(
+                    //     || "shuffle",
+                    //     config.shuffle,
+                    //     i,
+                    //     || Ok(F::from(i as u64+1).into()),
+                    // )?;
+                    region.assign_advice(
+                        || "shuffle",
+                        config.shuffle,
+                        i,
+                        || Ok(F::from(2 - i as u64).into()),
+                    )?;
+                }
+                region.assign_fixed(|| "", config.s, 0, || Ok(F::from(1).into()))?;
+                region.assign_fixed(|| "", config.s, 1, || Ok(F::from(1).into()))?;
+                Ok(())
+            },
+        )
+    }
+}
+
+fn test_prover(K: u32, circuit: MyCircuit<Fp>) {
+    let public_inputs_size = 0;
+    // Initialize the polynomial commitment parameters
+    let params: Params<G1Affine> = Params::<G1Affine>::unsafe_setup::<Bn256>(K);
+    let params_verifier: ParamsVerifier<Bn256> = params.verifier(public_inputs_size).unwrap();
+
+    let vk = keygen_vk(&params, &circuit).unwrap();
+    let pk = keygen_pk(&params, vk, &circuit).unwrap();
+
+    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+
+    create_proof(&params, &pk, &[circuit], &[&[]], OsRng, &mut transcript)
+        .expect("proof generation should not fail");
+
+    let proof = transcript.finalize();
+
+    let strategy = SingleVerifier::new(&params_verifier);
+    let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+    let a = verify_proof(
+        &params_verifier,
+        pk.get_vk(),
+        strategy,
+        &[&[]],
+        &mut transcript,
+    );
+    println!("a={:?}", a);
+    // assert!(verify_proof(
+    //     &params_verifier,
+    //     pk.get_vk(),
+    //     strategy,
+    //     &[&[]],
+    //     &mut transcript,
+    // )
+    // .is_ok());
+}
+
+fn main() {
+    // The number of rows in our circuit cannot exceed 2^k. Since our example
+    // circuit is very small, we can pick a very small value here.
+    let k = 3;
+
+    // Instantiate the circuit with the private inputs.
+
+    let circuit = MyCircuit::<Fp>::construct();
+
+    let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+    assert_eq!(prover.verify(), Ok(()));
+    // Arrange the public input. We expose the multiplication result in row 0
+    // of the instance column, so we position it there in our public inputs.
+    // let mut public_inputs = vec![c];
+
+    // Given the correct public input, our circuit will verify.
+    // let prover = MockProver::run(k, &circuit, vec![public_inputs.clone()]).unwrap();
+    // assert_eq!(prover.verify(), Ok(()));
+    test_prover(k, circuit);
+}

--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -1,11 +1,10 @@
 use group::ff::BatchInvert;
 use halo2_proofs::arithmetic::FieldExt;
-use halo2_proofs::circuit::{Cell, Chip, Layouter, Region, SimpleFloorPlanner};
+use halo2_proofs::circuit::{Layouter, SimpleFloorPlanner};
 use halo2_proofs::dev::MockProver;
 use halo2_proofs::plonk::*;
 use pairing::bn256::Fr as Fp;
 use pairing::bn256::{Bn256, G1Affine};
-use std::marker::PhantomData;
 
 use halo2_proofs::poly::{
     commitment::{Params, ParamsVerifier},
@@ -110,7 +109,7 @@ struct MyCircuit<F: FieldExt, const W: usize, const H: usize, const T: usize, co
 }
 
 impl<F: FieldExt, const W: usize, const H: usize, const T: usize, const G: usize> Default
-for MyCircuit<F, W, H, T, G>
+    for MyCircuit<F, W, H, T, G>
 {
     fn default() -> Self {
         Self {
@@ -121,7 +120,7 @@ for MyCircuit<F, W, H, T, G>
 }
 
 impl<F: FieldExt, const W: usize, const H: usize, const T: usize, const G: usize>
-MyCircuit<F, W, H, T, G>
+    MyCircuit<F, W, H, T, G>
 {
     fn rand<R: RngCore>(rng: &mut R) -> Self {
         let original = rand_2d_array::<F, _, W, H>(rng);
@@ -135,7 +134,7 @@ MyCircuit<F, W, H, T, G>
 }
 
 impl<F: FieldExt, const W: usize, const H: usize, const T: usize, const G: usize> Circuit<F>
-for MyCircuit<F, W, H, T, G>
+    for MyCircuit<F, W, H, T, G>
 {
     type Config = MyConfig<W, T, G>;
     type FloorPlanner = SimpleFloorPlanner;
@@ -166,7 +165,7 @@ for MyCircuit<F, W, H, T, G>
                 }
 
                 for (idx, (&column, values)) in
-                config.original.iter().zip(self.original.iter()).enumerate()
+                    config.original.iter().zip(self.original.iter()).enumerate()
                 {
                     for (offset, &value) in values.iter().enumerate() {
                         region.assign_advice(
@@ -178,7 +177,7 @@ for MyCircuit<F, W, H, T, G>
                     }
                 }
                 for (idx, (&column, values)) in
-                config.shuffled.iter().zip(self.shuffled.iter()).enumerate()
+                    config.shuffled.iter().zip(self.shuffled.iter()).enumerate()
                 {
                     for (offset, &value) in values.iter().enumerate() {
                         region.assign_advice(
@@ -217,7 +216,7 @@ for MyCircuit<F, W, H, T, G>
                         }
 
                         #[allow(clippy::let_and_return)]
-                            let z = std::iter::once(F::one())
+                        let z = std::iter::once(F::one())
                             .chain(product)
                             .scan(F::one(), |state, cur| {
                                 *state *= &cur;
@@ -248,12 +247,12 @@ for MyCircuit<F, W, H, T, G>
 }
 
 fn test_prover<const W: usize, const H: usize, const T: usize, const G: usize>(
-    K: u32,
+    k: u32,
     circuit: MyCircuit<Fp, W, H, T, G>,
 ) {
     let public_inputs_size = 0;
     // Initialize the polynomial commitment parameters
-    let params: Params<G1Affine> = Params::<G1Affine>::unsafe_setup::<Bn256>(K);
+    let params: Params<G1Affine> = Params::<G1Affine>::unsafe_setup::<Bn256>(k);
     let params_verifier: ParamsVerifier<Bn256> = params.verifier(public_inputs_size).unwrap();
 
     let vk = keygen_vk(&params, &circuit).unwrap();
@@ -276,7 +275,7 @@ fn test_prover<const W: usize, const H: usize, const T: usize, const G: usize>(
         &[&[]],
         &mut transcript,
     )
-        .is_ok());
+    .is_ok());
 }
 
 fn main() {

--- a/halo2_proofs/examples/shuffle_api.rs
+++ b/halo2_proofs/examples/shuffle_api.rs
@@ -59,6 +59,14 @@ impl<F: FieldExt> ShuffleChip<F> {
         s_input: Column<Fixed>,
         s_shuffle: Column<Fixed>,
     ) -> ShuffleConfig {
+        //need at least one gate or GPU will panic
+        meta.create_gate("", |meta| {
+            let input_0 = meta.query_advice(input_0, Rotation::cur());
+            let input_1 = meta.query_advice(input_1, Rotation::cur());
+            let s_input = meta.query_fixed(s_input, Rotation::cur());
+            vec![s_input * (input_0 * F::from(10) - input_1)]
+        });
+
         meta.shuffle("shuffle", |meta| {
             let input_0 = meta.query_advice(input_0, Rotation::cur());
             let shuffle_0 = meta.query_advice(shuffle_0, Rotation::cur());

--- a/halo2_proofs/examples/shuffle_api.rs
+++ b/halo2_proofs/examples/shuffle_api.rs
@@ -1,0 +1,200 @@
+use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::circuit::{Cell, Chip, Layouter, Region, SimpleFloorPlanner};
+use halo2_proofs::dev::MockProver;
+use halo2_proofs::plonk::*;
+use pairing::bn256::Fr as Fp;
+use pairing::bn256::{Bn256, G1Affine};
+
+use std::marker::PhantomData;
+
+use halo2_proofs::poly::{
+    commitment::{Params, ParamsVerifier},
+    Rotation,
+};
+use halo2_proofs::transcript::{Blake2bRead, Blake2bWrite, Challenge255};
+use rand_core::OsRng;
+
+#[derive(Clone, Debug)]
+struct ShuffleChip<F: FieldExt> {
+    config: ShuffleConfig,
+    _marker: PhantomData<F>,
+}
+
+#[derive(Clone, Debug)]
+struct ShuffleConfig {
+    input_0: Column<Advice>,
+    input_1: Column<Advice>,
+    shuffle_0: Column<Advice>,
+    shuffle_1: Column<Advice>,
+    s_input: Column<Fixed>,
+    s_shuffle: Column<Fixed>,
+}
+
+impl<F: FieldExt> Chip<F> for ShuffleChip<F> {
+    type Config = ShuffleConfig;
+    type Loaded = ();
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+    fn loaded(&self) -> &Self::Loaded {
+        &()
+    }
+}
+
+impl<F: FieldExt> ShuffleChip<F> {
+    fn construct(config: ShuffleConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        input_0: Column<Advice>,
+        input_1: Column<Advice>,
+        shuffle_0: Column<Advice>,
+        shuffle_1: Column<Advice>,
+        s_input: Column<Fixed>,
+        s_shuffle: Column<Fixed>,
+    ) -> ShuffleConfig {
+        meta.shuffle("shuffle", |meta| {
+            let input_0 = meta.query_advice(input_0, Rotation::cur());
+            let shuffle_0 = meta.query_advice(shuffle_0, Rotation::cur());
+            let input_1 = meta.query_advice(input_1, Rotation::cur());
+            let shuffle_1 = meta.query_advice(shuffle_1, Rotation::cur());
+            let s_input = meta.query_fixed(s_input, Rotation::cur());
+            let s_shuffle = meta.query_fixed(s_shuffle, Rotation::cur());
+
+            [
+                (s_input.clone() * input_0, s_shuffle.clone() * shuffle_0),
+                (s_input * input_1, s_shuffle * shuffle_1),
+            ]
+            .to_vec()
+        });
+
+        ShuffleConfig {
+            input_0,
+            input_1,
+            shuffle_0,
+            shuffle_1,
+            s_input,
+            s_shuffle,
+        }
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+struct MyCircuit<F: FieldExt> {
+    input0: Vec<F>,
+    input1: Vec<F>,
+    shuffle0: Vec<F>,
+    shuffle1: Vec<F>,
+}
+
+impl<F: FieldExt> MyCircuit<F> {
+    fn construct() -> Self {
+        Self {
+            input0: [1, 2, 4, 1].map(|x| F::from(x as u64)).to_vec(),
+            shuffle0: [4, 1, 1, 2].map(|x| F::from(x as u64)).to_vec(),
+            input1: [10, 20, 40, 10].map(|x| F::from(x as u64)).to_vec(),
+            shuffle1: [40, 10, 10, 20].map(|x| F::from(x as u64)).to_vec(),
+        }
+    }
+}
+
+impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
+    type Config = ShuffleConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        let [input_0, input_1, shuffle_0, shuffle_1] = [(); 4].map(|_| meta.advice_column());
+        let [s_input, s_shuffle] = [(); 2].map(|_| meta.fixed_column());
+
+        ShuffleChip::configure(
+            meta, input_0, input_1, shuffle_0, shuffle_1, s_input, s_shuffle,
+        )
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let ch = ShuffleChip::<F>::construct(config.clone());
+
+        layouter.assign_region(
+            || "shuffle0",
+            |mut region: Region<'_, F>| {
+                for (i, (input, shuffle)) in
+                    self.input0.iter().zip(self.shuffle0.iter()).enumerate()
+                {
+                    region.assign_advice(|| "", ch.config.input_0, i, || Ok(*input))?;
+                    region.assign_advice(|| "", ch.config.shuffle_0, i, || Ok(*shuffle))?;
+
+                    region.assign_fixed(|| "", ch.config.s_input, i, || Ok(F::from(1)))?;
+                    region.assign_fixed(|| "", ch.config.s_shuffle, i, || Ok(F::from(1)))?;
+                }
+                Ok(())
+            },
+        )?;
+        layouter.assign_region(
+            || "shuffle1",
+            |mut region: Region<'_, F>| {
+                for (i, (input, shuffle)) in
+                    self.input1.iter().zip(self.shuffle1.iter()).enumerate()
+                {
+                    region.assign_advice(|| "", ch.config.input_1, i, || Ok(*input))?;
+                    region.assign_advice(|| "", ch.config.shuffle_1, i, || Ok(*shuffle))?;
+                }
+                Ok(())
+            },
+        )
+    }
+}
+
+fn test_prover(K: u32, circuit: MyCircuit<Fp>) {
+    let public_inputs_size = 0;
+    // Initialize the polynomial commitment parameters
+    let params: Params<G1Affine> = Params::<G1Affine>::unsafe_setup::<Bn256>(K);
+    let params_verifier: ParamsVerifier<Bn256> = params.verifier(public_inputs_size).unwrap();
+
+    let vk = keygen_vk(&params, &circuit).unwrap();
+    let pk = keygen_pk(&params, vk, &circuit).unwrap();
+
+    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+
+    create_proof(&params, &pk, &[circuit], &[&[]], OsRng, &mut transcript)
+        .expect("proof generation should not fail");
+
+    let proof = transcript.finalize();
+
+    let strategy = SingleVerifier::new(&params_verifier);
+    let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+
+    assert!(verify_proof(
+        &params_verifier,
+        pk.get_vk(),
+        strategy,
+        &[&[]],
+        &mut transcript,
+    )
+    .is_ok());
+}
+
+fn main() {
+    // The number of rows in our circuit cannot exceed 2^k
+    let k = 10;
+
+    let circuit = MyCircuit::<Fp>::construct();
+
+    let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+    assert_eq!(prover.verify(), Ok(()));
+
+    test_prover(k, circuit);
+}

--- a/halo2_proofs/examples/shuffle_api_group.rs
+++ b/halo2_proofs/examples/shuffle_api_group.rs
@@ -55,6 +55,14 @@ impl<F: FieldExt> ShuffleChip<F> {
         s_inputs: &[Column<Fixed>],
         s_shuffles: &[Column<Fixed>],
     ) -> ShuffleConfig {
+        //need at least one gate or GPU will panic
+        meta.create_gate("", |meta| {
+            let input_0 = meta.query_advice(inputs[0], Rotation::cur());
+            let input_1 = meta.query_advice(inputs[1], Rotation::cur());
+            let s_input = meta.query_fixed(s_inputs[0], Rotation::cur());
+            vec![s_input * (input_0 - input_1)]
+        });
+
         meta.shuffle("shuffle1", |meta| {
             let input_0 = meta.query_advice(inputs[0], Rotation::cur());
             let shuffle_0 = meta.query_advice(shuffles[0], Rotation::cur());
@@ -65,27 +73,29 @@ impl<F: FieldExt> ShuffleChip<F> {
         });
 
         meta.shuffle("shuffle2", |meta| {
-            let input_0 = meta.query_advice(inputs[2], Rotation::cur());
-            let shuffle_0 = meta.query_advice(shuffles[2], Rotation::cur());
-            [(input_0, shuffle_0)].to_vec()
+            let input = meta.query_advice(inputs[2], Rotation::cur());
+            let shuffle = meta.query_advice(shuffles[2], Rotation::cur());
+            [(input, shuffle)].to_vec()
         });
 
         meta.shuffle("shuffle3", |meta| {
-            let input_0 = meta.query_advice(inputs[3], Rotation::cur());
-            let shuffle_0 = meta.query_advice(shuffles[3], Rotation::cur());
-            [(input_0, shuffle_0)].to_vec()
+            let input = meta.query_advice(inputs[3], Rotation::cur());
+            let shuffle = meta.query_advice(shuffles[3], Rotation::cur());
+            let s_input = meta.query_fixed(s_inputs[0], Rotation::cur());
+            let s_shuffle = meta.query_fixed(s_shuffles[0], Rotation::cur());
+            [(input * s_input, shuffle * s_shuffle)].to_vec()
         });
 
         meta.shuffle("shuffle4", |meta| {
-            let input_0 = meta.query_advice(inputs[4], Rotation::cur());
-            let shuffle_0 = meta.query_advice(shuffles[4], Rotation::cur());
+            let input = meta.query_advice(inputs[4], Rotation::cur());
+            let shuffle = meta.query_advice(shuffles[4], Rotation::cur());
             let s_input0 = meta.query_fixed(s_inputs[0], Rotation::cur());
             let s_shuffle0 = meta.query_fixed(s_shuffles[0], Rotation::cur());
             let s_input1 = meta.query_fixed(s_inputs[1], Rotation::cur());
             let s_shuffle1 = meta.query_fixed(s_shuffles[1], Rotation::cur());
             [(
-                input_0 * s_input0 * s_input1,
-                shuffle_0 * s_shuffle0 * s_shuffle1,
+                input * s_input0 * s_input1,
+                shuffle * s_shuffle0 * s_shuffle1,
             )]
             .to_vec()
         });

--- a/halo2_proofs/examples/shuffle_api_group.rs
+++ b/halo2_proofs/examples/shuffle_api_group.rs
@@ -1,0 +1,207 @@
+use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::circuit::{Chip, Layouter, Region, SimpleFloorPlanner};
+use halo2_proofs::dev::MockProver;
+use halo2_proofs::plonk::*;
+use pairing::bn256::Fr as Fp;
+use pairing::bn256::{Bn256, G1Affine};
+
+use std::marker::PhantomData;
+
+use halo2_proofs::poly::{
+    commitment::{Params, ParamsVerifier},
+    Rotation,
+};
+use halo2_proofs::transcript::{Blake2bRead, Blake2bWrite, Challenge255};
+use rand_core::OsRng;
+
+#[derive(Clone, Debug)]
+struct ShuffleChip<F: FieldExt> {
+    config: ShuffleConfig,
+    _marker: PhantomData<F>,
+}
+
+#[derive(Clone, Debug)]
+struct ShuffleConfig {
+    inputs: Vec<Column<Advice>>,
+    shuffles: Vec<Column<Advice>>,
+    s_inputs: Vec<Column<Fixed>>,
+    s_shuffles: Vec<Column<Fixed>>,
+}
+
+impl<F: FieldExt> Chip<F> for ShuffleChip<F> {
+    type Config = ShuffleConfig;
+    type Loaded = ();
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+    fn loaded(&self) -> &Self::Loaded {
+        &()
+    }
+}
+
+impl<F: FieldExt> ShuffleChip<F> {
+    fn construct(config: ShuffleConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        inputs: &[Column<Advice>],
+        shuffles: &[Column<Advice>],
+        s_inputs: &[Column<Fixed>],
+        s_shuffles: &[Column<Fixed>],
+    ) -> ShuffleConfig {
+        meta.shuffle("shuffle1", |meta| {
+            let input_0 = meta.query_advice(inputs[0], Rotation::cur());
+            let shuffle_0 = meta.query_advice(shuffles[0], Rotation::cur());
+            let input_1 = meta.query_advice(inputs[1], Rotation::cur());
+            let shuffle_1 = meta.query_advice(shuffles[1], Rotation::cur());
+
+            [(input_0, shuffle_0), (input_1, shuffle_1)].to_vec()
+        });
+
+        meta.shuffle("shuffle2", |meta| {
+            let input_0 = meta.query_advice(inputs[2], Rotation::cur());
+            let shuffle_0 = meta.query_advice(shuffles[2], Rotation::cur());
+            [(input_0, shuffle_0)].to_vec()
+        });
+
+        meta.shuffle("shuffle3", |meta| {
+            let input_0 = meta.query_advice(inputs[3], Rotation::cur());
+            let shuffle_0 = meta.query_advice(shuffles[3], Rotation::cur());
+            [(input_0, shuffle_0)].to_vec()
+        });
+
+        meta.shuffle("shuffle4", |meta| {
+            let input_0 = meta.query_advice(inputs[4], Rotation::cur());
+            let shuffle_0 = meta.query_advice(shuffles[4], Rotation::cur());
+            let s_input0 = meta.query_fixed(s_inputs[0], Rotation::cur());
+            let s_shuffle0 = meta.query_fixed(s_shuffles[0], Rotation::cur());
+            let s_input1 = meta.query_fixed(s_inputs[1], Rotation::cur());
+            let s_shuffle1 = meta.query_fixed(s_shuffles[1], Rotation::cur());
+            [(
+                input_0 * s_input0 * s_input1,
+                shuffle_0 * s_shuffle0 * s_shuffle1,
+            )]
+            .to_vec()
+        });
+
+        ShuffleConfig {
+            inputs: inputs.to_vec(),
+            shuffles: shuffles.to_vec(),
+            s_inputs: s_inputs.to_vec(),
+            s_shuffles: s_shuffles.to_vec(),
+        }
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+struct MyCircuit<F: FieldExt> {
+    input0: Vec<F>,
+    input1: Vec<F>,
+}
+
+impl<F: FieldExt> MyCircuit<F> {
+    fn construct() -> Self {
+        Self {
+            input0: [1, 2, 4, 1].map(|x| F::from(x as u64)).to_vec(),
+            input1: [4, 1, 1, 2].map(|x| F::from(x as u64)).to_vec(),
+        }
+    }
+}
+
+impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
+    type Config = ShuffleConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        let inputs: Vec<_> = (0..5).into_iter().map(|_| meta.advice_column()).collect();
+        let shuffles: Vec<_> = (0..5).into_iter().map(|_| meta.advice_column()).collect();
+        let s_inputs: Vec<_> = (0..2).into_iter().map(|_| meta.fixed_column()).collect();
+        let s_shuffles: Vec<_> = (0..2).into_iter().map(|_| meta.fixed_column()).collect();
+        ShuffleChip::configure(meta, &inputs, &shuffles, &s_inputs, &s_shuffles)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let ch = ShuffleChip::<F>::construct(config.clone());
+
+        layouter.assign_region(
+            || "inputs",
+            |mut region: Region<'_, F>| {
+                for (i, (input0, input1)) in self.input0.iter().zip(self.input1.iter()).enumerate()
+                {
+                    region.assign_advice(|| "", ch.config.inputs[0], i, || Ok(*input0))?;
+                    region.assign_advice(|| "", ch.config.inputs[1], i, || Ok(*input0))?;
+                    region.assign_advice(|| "", ch.config.inputs[2], i, || Ok(*input0))?;
+                    region.assign_advice(|| "", ch.config.inputs[3], i, || Ok(*input0))?;
+                    region.assign_advice(|| "", ch.config.inputs[4], i, || Ok(*input0))?;
+
+                    region.assign_advice(|| "", ch.config.shuffles[0], i, || Ok(*input1))?;
+                    region.assign_advice(|| "", ch.config.shuffles[1], i, || Ok(*input1))?;
+                    region.assign_advice(|| "", ch.config.shuffles[2], i, || Ok(*input1))?;
+                    region.assign_advice(|| "", ch.config.shuffles[3], i, || Ok(*input1))?;
+                    region.assign_advice(|| "", ch.config.shuffles[4], i, || Ok(*input1))?;
+
+                    region.assign_fixed(|| "", ch.config.s_inputs[0], i, || Ok(F::from(1)))?;
+                    region.assign_fixed(|| "", ch.config.s_shuffles[0], i, || Ok(F::from(1)))?;
+                    region.assign_fixed(|| "", ch.config.s_inputs[1], i, || Ok(F::from(1)))?;
+                    region.assign_fixed(|| "", ch.config.s_shuffles[1], i, || Ok(F::from(1)))?;
+                }
+                Ok(())
+            },
+        )
+    }
+}
+
+fn test_prover(k: u32, circuit: MyCircuit<Fp>) {
+    let public_inputs_size = 0;
+    // Initialize the polynomial commitment parameters
+    let params: Params<G1Affine> = Params::<G1Affine>::unsafe_setup::<Bn256>(k);
+    let params_verifier: ParamsVerifier<Bn256> = params.verifier(public_inputs_size).unwrap();
+
+    let vk = keygen_vk(&params, &circuit).unwrap();
+    let pk = keygen_pk(&params, vk, &circuit).unwrap();
+
+    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+
+    create_proof(&params, &pk, &[circuit], &[&[]], OsRng, &mut transcript)
+        .expect("proof generation should not fail");
+
+    let proof = transcript.finalize();
+
+    let strategy = SingleVerifier::new(&params_verifier);
+    let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+
+    assert!(verify_proof(
+        &params_verifier,
+        pk.get_vk(),
+        strategy,
+        &[&[]],
+        &mut transcript,
+    )
+    .is_ok());
+}
+
+fn main() {
+    // The number of rows in our circuit cannot exceed 2^k
+    let k = 10;
+
+    let circuit = MyCircuit::<Fp>::construct();
+
+    let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+    assert_eq!(prover.verify(), Ok(()));
+
+    test_prover(k, circuit);
+}

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1113,6 +1113,7 @@ impl<F: FieldExt> MockVerifier<F> {
         let shuffle_errors =
             self.cs
                 .shuffles
+                .0
                 .iter()
                 .enumerate()
                 .flat_map(|(shuffle_index, shuffle)| {

--- a/halo2_proofs/src/helpers.rs
+++ b/halo2_proofs/src/helpers.rs
@@ -418,6 +418,11 @@ pub(crate) fn write_cs<C: CurveAffine, W: io::Write>(
         p.input_expressions.store(writer)?;
         p.table_expressions.store(writer)?;
     }
+    writer.write(&(cs.shuffles.len() as u32).to_le_bytes())?;
+    for p in cs.shuffles.iter() {
+        p.input_expressions.store(writer)?;
+        p.shuffle_expressions.store(writer)?;
+    }
     cs.named_advices.store(writer)?;
     write_gates::<C, W>(&cs.gates, writer)?;
     Ok(())
@@ -456,6 +461,17 @@ pub(crate) fn read_cs<C: CurveAffine, R: io::Read>(
             table_expressions,
         });
     }
+    let mut shuffles = vec![];
+    let nb_shuffle = read_u32(reader)?;
+    for _ in 0..nb_shuffle {
+        let input_expressions = Vec::<Expression<C::Scalar>>::fetch(reader)?;
+        let shuffle_expressions = Vec::<Expression<C::Scalar>>::fetch(reader)?;
+        shuffles.push(plonk::shuffle::Argument {
+            name: "",
+            input_expressions,
+            shuffle_expressions,
+        });
+    }
     let named_advices = Vec::fetch(reader)?;
     let gates = read_gates::<C, R>(reader)?;
     Ok(ConstraintSystem {
@@ -472,6 +488,7 @@ pub(crate) fn read_cs<C: CurveAffine, R: io::Read>(
         named_advices,
         permutation,
         lookups,
+        shuffles,
         constants,
         minimum_degree: None,
     })

--- a/halo2_proofs/src/helpers.rs
+++ b/halo2_proofs/src/helpers.rs
@@ -418,8 +418,8 @@ pub(crate) fn write_cs<C: CurveAffine, W: io::Write>(
         p.input_expressions.store(writer)?;
         p.table_expressions.store(writer)?;
     }
-    writer.write(&(cs.shuffles.len() as u32).to_le_bytes())?;
-    for p in cs.shuffles.iter() {
+    writer.write(&(cs.shuffles.0.len() as u32).to_le_bytes())?;
+    for p in cs.shuffles.0.iter() {
         p.input_expressions.store(writer)?;
         p.shuffle_expressions.store(writer)?;
     }
@@ -461,12 +461,12 @@ pub(crate) fn read_cs<C: CurveAffine, R: io::Read>(
             table_expressions,
         });
     }
-    let mut shuffles = vec![];
+    let mut shuffles = plonk::shuffle::Argument(vec![]);
     let nb_shuffle = read_u32(reader)?;
     for _ in 0..nb_shuffle {
         let input_expressions = Vec::<Expression<C::Scalar>>::fetch(reader)?;
         let shuffle_expressions = Vec::<Expression<C::Scalar>>::fetch(reader)?;
-        shuffles.push(plonk::shuffle::Argument {
+        shuffles.0.push(plonk::shuffle::ArgumentElement {
             name: "",
             input_expressions,
             shuffle_expressions,

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -24,6 +24,7 @@ mod evaluation;
 mod keygen;
 pub(crate) mod lookup;
 pub(crate) mod permutation;
+pub(crate) mod shuffle;
 mod vanishing;
 
 mod prover;

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -267,10 +267,6 @@ struct Gamma;
 type ChallengeGamma<F> = ChallengeScalar<F, Gamma>;
 
 #[derive(Clone, Copy, Debug)]
-struct Delta;
-type ChallengeDelta<F> = ChallengeScalar<F, Delta>;
-
-#[derive(Clone, Copy, Debug)]
 struct Y;
 type ChallengeY<F> = ChallengeScalar<F, Y>;
 

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -267,6 +267,10 @@ struct Gamma;
 type ChallengeGamma<F> = ChallengeScalar<F, Gamma>;
 
 #[derive(Clone, Copy, Debug)]
+struct Delta;
+type ChallengeDelta<F> = ChallengeScalar<F, Delta>;
+
+#[derive(Clone, Copy, Debug)]
 struct Y;
 type ChallengeY<F> = ChallengeScalar<F, Y>;
 

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -6,7 +6,7 @@ use std::{
     ops::{Neg, Sub},
 };
 
-use super::{lookup, permutation, Assigned, Error};
+use super::{lookup, permutation, shuffle, Assigned, Error};
 use crate::circuit::Layouter;
 use crate::{circuit::Region, poly::Rotation};
 
@@ -1103,6 +1103,10 @@ pub struct ConstraintSystem<F: Field> {
     // input expressions and a sequence of table expressions involved in the lookup.
     pub lookups: Vec<lookup::Argument<F>>,
 
+    // Vector of lookup arguments, where each corresponds to a sequence of
+    // input expressions and a sequence of table expressions involved in the lookup.
+    pub shuffles: Vec<shuffle::Argument<F>>,
+
     // Vector of fixed columns, which can be used to store constant values
     // that are copied into advice columns.
     pub(crate) constants: Vec<Column<Fixed>>,
@@ -1125,6 +1129,7 @@ pub struct PinnedConstraintSystem<'a, F: Field> {
     fixed_queries: &'a Vec<(Column<Fixed>, Rotation)>,
     permutation: &'a permutation::Argument,
     lookups: PinnedLookups<'a, F>,
+    shuffles: PinnedShuffles<'a, F>,
     constants: &'a Vec<Column<Fixed>>,
     minimum_degree: &'a Option<usize>,
 }
@@ -1139,6 +1144,22 @@ impl<'a, F: Field> std::fmt::Debug for PinnedLookups<'a, F> {
                     format!("lookup{}", i),
                     &arg.input_expressions,
                     &arg.table_expressions,
+                )
+            }))
+            .finish()
+    }
+}
+
+struct PinnedShuffles<'a, F: Field>(&'a Vec<shuffle::Argument<F>>);
+
+impl<'a, F: Field> std::fmt::Debug for PinnedShuffles<'a, F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_list()
+            .entries(self.0.iter().enumerate().map(|(i, arg)| {
+                (
+                    format!("shuffle{}", i),
+                    &arg.input_expressions,
+                    &arg.shuffle_expressions,
                 )
             }))
             .finish()
@@ -1171,6 +1192,7 @@ impl<F: Field> Default for ConstraintSystem<F> {
             instance_queries: Vec::new(),
             permutation: permutation::Argument::new(),
             lookups: Vec::new(),
+            shuffles: Vec::new(),
             constants: vec![],
             minimum_degree: None,
         }
@@ -1194,6 +1216,7 @@ impl<F: Field> ConstraintSystem<F> {
             instance_queries: &self.instance_queries,
             permutation: &self.permutation,
             lookups: PinnedLookups(&self.lookups),
+            shuffles: PinnedShuffles(&self.shuffles),
             constants: &self.constants,
             minimum_degree: &self.minimum_degree,
         }
@@ -1265,6 +1288,25 @@ impl<F: Field> ConstraintSystem<F> {
         let index = self.lookups.len();
 
         self.lookups.push(lookup::Argument::new(name, table_map));
+
+        index
+    }
+
+    /// Add a shuffle argument for some input expressions and any columns.
+    ///
+    /// `table_map` returns a map between input expressions and the table columns
+    /// they need to match.
+    pub fn shuffle(
+        &mut self,
+        name: &'static str,
+        table_map: impl FnOnce(&mut VirtualCells<'_, F>) -> Vec<(Expression<F>, Expression<F>)>,
+    ) -> usize {
+        let mut cells = VirtualCells::new(self);
+        let table_map = table_map(&mut cells);
+
+        let index = self.shuffles.len();
+
+        self.shuffles.push(shuffle::Argument::new(name, table_map));
 
         index
     }
@@ -1536,6 +1578,16 @@ impl<F: Field> ConstraintSystem<F> {
             replace_selectors(expr, &selector_replacements, true);
         }
 
+        // Substitute non-simple selectors for the real fixed columns in all
+        // shuffle expressions
+        for expr in self.shuffles.iter_mut().flat_map(|shuffle| {
+            shuffle
+                .input_expressions
+                .iter_mut()
+                .chain(shuffle.shuffle_expressions.iter_mut())
+        }) {
+            replace_selectors(expr, &selector_replacements, true);
+        }
         (self, polys)
     }
 
@@ -1620,6 +1672,15 @@ impl<F: Field> ConstraintSystem<F> {
         degree = std::cmp::max(
             degree,
             self.lookups
+                .iter()
+                .map(|l| l.required_degree())
+                .max()
+                .unwrap_or(1),
+        );
+
+        degree = std::cmp::max(
+            degree,
+            self.shuffles
                 .iter()
                 .map(|l| l.required_degree())
                 .max()

--- a/halo2_proofs/src/plonk/evaluation.rs
+++ b/halo2_proofs/src/plonk/evaluation.rs
@@ -209,14 +209,16 @@ impl Calculation {
                     advice_values,
                     instance_values,
                 );
-                let mut x = match lcx {
+                let x = match lcx {
                     LcChallenge::Beta => beta,
                     LcChallenge::Gamma => gamma,
                 };
+
                 if *p > 1 {
-                    x = x.pow_vartime([*p as u64, 0, 0, 0]);
+                    (a + x.pow_vartime([*p as u64, 0, 0, 0])) * b
+                } else {
+                    (a + x) * b
                 }
-                (a + x) * b
             }
             Calculation::LcTheta(a, b) => {
                 let a = a.get(

--- a/halo2_proofs/src/plonk/evaluation.rs
+++ b/halo2_proofs/src/plonk/evaluation.rs
@@ -390,7 +390,8 @@ impl<C: CurveAffine> Evaluator<C> {
             let shuffle_coset = evaluate_lc(&mut ev, &shuffle.shuffle_expressions);
             // z(\omega X) (s(X) + \gamma) - z(x) (a(X) + \gamma)
             ev.shuffle_results.push(Calculation::AddGamma(input_coset));
-            ev.shuffle_results.push(Calculation::AddGamma(shuffle_coset));
+            ev.shuffle_results
+                .push(Calculation::AddGamma(shuffle_coset));
         }
 
         // Lookups in GPU

--- a/halo2_proofs/src/plonk/evaluation.rs
+++ b/halo2_proofs/src/plonk/evaluation.rs
@@ -390,8 +390,7 @@ impl<C: CurveAffine> Evaluator<C> {
             let shuffle_coset = evaluate_lc(&mut ev, &shuffle.shuffle_expressions);
             // z(\omega X) (s(X) + \gamma) - z(x) (a(X) + \gamma)
             ev.shuffle_results.push(Calculation::AddGamma(input_coset));
-            ev.shuffle_results
-                .push(Calculation::AddGamma(shuffle_coset));
+            ev.shuffle_results.push(Calculation::AddGamma(shuffle_coset));
         }
 
         // Lookups in GPU
@@ -577,8 +576,7 @@ impl<C: CurveAffine> Evaluator<C> {
     }
 
     /// Evaluate h poly
-    // #[cfg(not(feature = "cuda"))]
-    #[cfg(feature = "gwc")]
+    #[cfg(not(feature = "cuda"))]
     pub(in crate::plonk) fn evaluate_h(
         &self,
         pk: &ProvingKey<C>,
@@ -897,11 +895,11 @@ impl<C: CurveAffine> Evaluator<C> {
                             *value = *value * y
                                 + ((product_coset[idx] * product_coset[idx] - product_coset[idx])
                                     * l_last[idx]);
+
                             // (1 - (l_last(X) + l_blind(X))) * (
                             //   z(\omega X) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
                             //   - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta)
                             // ) = 0
-
                             *value = *value * y
                                 + ((product_coset[r_next] * (shuffle_coset[idx])
                                     - product_coset[idx] * input_coset[idx])
@@ -1395,7 +1393,6 @@ impl<C: CurveAffine> Evaluator<C> {
                             }
 
                             let y_beta_gamma = vec![y, beta, gamma];
-
                             let values_buf =
                                 unsafe { program.create_buffer(domain.extended_len())? };
                             create_buffer_from!(y_beta_gamma_buf, &y_beta_gamma[..]);
@@ -1418,7 +1415,7 @@ impl<C: CurveAffine> Evaluator<C> {
                             for (shuffle_idx, shuffle) in shuffles.iter().enumerate() {
                                 let mut ys = vec![C::ScalarExt::one(), y];
                                 let input_coset_buf = pk.ev.gpu_shuffle_expr
-                                    [shuffles_idx + group_idx * group_expr_len]
+                                    [shuffle_idx + group_idx * group_expr_len]
                                     .0
                                     ._eval_gpu(
                                         pk,
@@ -1436,10 +1433,8 @@ impl<C: CurveAffine> Evaluator<C> {
                                     )
                                     .unwrap()
                                     .0;
-                                //todo check ys more
-                                let mut ys = vec![C::ScalarExt::one(), y];
                                 let shuffle_coset_buf = pk.ev.gpu_shuffle_expr
-                                    [shuffles_idx + group_idx * group_expr_len]
+                                    [shuffle_idx + group_idx * group_expr_len]
                                     .1
                                     ._eval_gpu(
                                         pk,
@@ -1456,7 +1451,6 @@ impl<C: CurveAffine> Evaluator<C> {
                                     )
                                     .unwrap()
                                     .0;
-
                                 let product_coset_buf = do_extended_fft(
                                     pk,
                                     program,
@@ -1475,8 +1469,8 @@ impl<C: CurveAffine> Evaluator<C> {
                                 )?;
                                 kernel
                                     .arg(&values_buf)
-                                    .arg(&input_coset_buf)
-                                    .arg(&shuffle_coset_buf)
+                                    .arg(input_coset_buf.as_ref())
+                                    .arg(shuffle_coset_buf.as_ref())
                                     .arg(&product_coset_buf)
                                     .arg(&l0_buf)
                                     .arg(&l_last_buf)

--- a/halo2_proofs/src/plonk/evaluation_gpu.rs
+++ b/halo2_proofs/src/plonk/evaluation_gpu.rs
@@ -251,7 +251,6 @@ use ec_gpu_gen::{
 };
 use pairing::bn256::Bn256;
 
-
 #[cfg(feature = "cuda")]
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) enum CacheAction {

--- a/halo2_proofs/src/plonk/evaluation_gpu.rs
+++ b/halo2_proofs/src/plonk/evaluation_gpu.rs
@@ -122,12 +122,12 @@ impl<F: FieldExt> LookupProveExpression<F> {
             ),
             LookupProveExpression::LcTheta(l, r) => {
                 let l = l._eval_gpu(
-                    pk, program, advice, instance, y, beta, theta, gamma, unit_cache, allocator,
-                    helper,
+                    pk, program, advice, instance, y, beta, theta, gamma, delta, unit_cache,
+                    allocator, helper,
                 )?;
                 let r = r._eval_gpu(
-                    pk, program, advice, instance, y, beta, theta, gamma, unit_cache, allocator,
-                    helper,
+                    pk, program, advice, instance, y, beta, theta, gamma, delta, unit_cache,
+                    allocator, helper,
                 )?;
                 let res = if r.1 == 0 && Rc::strong_count(&r.0) == 1 {
                     r.0.clone()
@@ -169,12 +169,12 @@ impl<F: FieldExt> LookupProveExpression<F> {
             }
             LookupProveExpression::LcChallenge(l, r, lcx) => {
                 let l = l._eval_gpu(
-                    pk, program, advice, instance, y, beta, theta, gamma, unit_cache, allocator,
-                    helper,
+                    pk, program, advice, instance, y, beta, theta, gamma, delta, unit_cache,
+                    allocator, helper,
                 )?;
                 let r = r._eval_gpu(
-                    pk, program, advice, instance, y, beta, theta, gamma, unit_cache, allocator,
-                    helper,
+                    pk, program, advice, instance, y, beta, theta, gamma, delta, unit_cache,
+                    allocator, helper,
                 )?;
                 let res = if r.1 == 0 && Rc::strong_count(&r.0) == 1 {
                     r.0.clone()
@@ -186,9 +186,9 @@ impl<F: FieldExt> LookupProveExpression<F> {
                     }))
                 };
                 let x = match lcx {
-                    LcX::Beta => beta,
-                    LcX::Gamma => gamma,
-                    LcX::Delta => delta,
+                    LcChallenge::Beta => beta,
+                    LcChallenge::Gamma => gamma,
+                    LcChallenge::Delta => delta,
                 };
                 let beta = program.create_buffer_from_slice(&vec![x])?;
                 let kernel_name = format!("{}_eval_lcbeta", "Bn256_Fr");
@@ -220,8 +220,8 @@ impl<F: FieldExt> LookupProveExpression<F> {
             }
             LookupProveExpression::AddChallenge(l, lcx) => {
                 let l = l._eval_gpu(
-                    pk, program, advice, instance, y, beta, theta, gamma, unit_cache, allocator,
-                    helper,
+                    pk, program, advice, instance, y, beta, theta, gamma, delta, unit_cache,
+                    allocator, helper,
                 )?;
                 let res = if l.1 == 0 && Rc::strong_count(&l.0) == 1 {
                     l.0.clone()
@@ -231,9 +231,9 @@ impl<F: FieldExt> LookupProveExpression<F> {
                     }))
                 };
                 let x = match lcx {
-                    LcX::Beta => beta,
-                    LcX::Gamma => gamma,
-                    LcX::Delta => delta,
+                    LcChallenge::Beta => beta,
+                    LcChallenge::Gamma => gamma,
+                    LcChallenge::Delta => delta,
                 };
                 let gamma = program.create_buffer_from_slice(&vec![x])?;
                 let kernel_name = format!("{}_eval_addgamma", "Bn256_Fr");

--- a/halo2_proofs/src/plonk/evaluation_gpu.rs
+++ b/halo2_proofs/src/plonk/evaluation_gpu.rs
@@ -249,7 +249,6 @@ use ec_gpu_gen::{
     fft::FftKernel, rust_gpu_tools::cuda::Buffer, rust_gpu_tools::cuda::Program,
     rust_gpu_tools::Device, rust_gpu_tools::LocalBuffer, EcResult,
 };
-use pairing::bn256::Bn256;
 
 #[cfg(feature = "cuda")]
 #[derive(Debug, PartialEq, Clone)]

--- a/halo2_proofs/src/plonk/evaluation_gpu.rs
+++ b/halo2_proofs/src/plonk/evaluation_gpu.rs
@@ -249,6 +249,8 @@ use ec_gpu_gen::{
     fft::FftKernel, rust_gpu_tools::cuda::Buffer, rust_gpu_tools::cuda::Program,
     rust_gpu_tools::Device, rust_gpu_tools::LocalBuffer, EcResult,
 };
+use pairing::bn256::Bn256;
+
 
 #[cfg(feature = "cuda")]
 #[derive(Debug, PartialEq, Clone)]

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -32,6 +32,7 @@ use super::{
 };
 use crate::arithmetic::eval_polynomial_st;
 use crate::plonk::lookup::prover::Permuted;
+use crate::plonk::ChallengeDelta;
 use crate::{
     arithmetic::{eval_polynomial, BaseExt, CurveAffine, FieldExt},
     plonk::Assigned,
@@ -347,6 +348,8 @@ pub fn create_proof_ext<
     let beta: ChallengeBeta<_> = transcript.squeeze_challenge_scalar();
     // Sample gamma challenge
     let gamma: ChallengeGamma<_> = transcript.squeeze_challenge_scalar();
+    // Sample delta challenge
+    let delta: ChallengeDelta<_> = transcript.squeeze_challenge_scalar();
 
     let (lookups, shuffles, permutations) = std::thread::scope(|s| {
         let permutations = s.spawn(|| {
@@ -435,7 +438,11 @@ pub fn create_proof_ext<
             .map(|shuffles| {
                 shuffles
                     .into_par_iter()
-                    .map(|shuffle| shuffle.commit_product(pk, params, gamma.clone()).unwrap())
+                    .map(|shuffle| {
+                        shuffle
+                            .commit_product(pk, params, beta, gamma, delta)
+                            .unwrap()
+                    })
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
@@ -594,6 +601,7 @@ pub fn create_proof_ext<
         *y,
         *beta,
         *gamma,
+        *delta,
         *theta,
         &lookups,
         &shuffles,
@@ -608,6 +616,7 @@ pub fn create_proof_ext<
         *y,
         *beta,
         *gamma,
+        *delta,
         *theta,
         &lookups,
         &shuffles,
@@ -1002,6 +1011,8 @@ pub fn create_proof_from_witness<
     let beta: ChallengeBeta<_> = transcript.squeeze_challenge_scalar();
     // Sample gamma challenge
     let gamma: ChallengeGamma<_> = transcript.squeeze_challenge_scalar();
+    // Sample delta challenge
+    let delta: ChallengeDelta<_> = transcript.squeeze_challenge_scalar();
 
     let (lookups, shuffles, permutations) = std::thread::scope(|s| {
         let permutations = s.spawn(|| {
@@ -1090,7 +1101,11 @@ pub fn create_proof_from_witness<
             .map(|shuffles| {
                 shuffles
                     .into_par_iter()
-                    .map(|shuffle| shuffle.commit_product(pk, params, gamma.clone()).unwrap())
+                    .map(|shuffle| {
+                        shuffle
+                            .commit_product(pk, params, beta, gamma, delta)
+                            .unwrap()
+                    })
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
@@ -1249,6 +1264,7 @@ pub fn create_proof_from_witness<
         *y,
         *beta,
         *gamma,
+        *delta,
         *theta,
         &lookups,
         &shuffles,
@@ -1263,6 +1279,7 @@ pub fn create_proof_from_witness<
         *y,
         *beta,
         *gamma,
+        *delta,
         *theta,
         &lookups,
         &shuffles,

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -313,14 +313,17 @@ pub fn create_proof_ext<
     });
     end_timer!(timer);
 
-    let timer = start_timer!(|| format!("shuffles {}", pk.vk.cs.shuffles.len()));
+    let shuffle_groups = pk.vk.cs.shuffles.group(pk.vk.cs.degree());
+    let timer = start_timer!(|| format!(
+        "total shuffles {},groups:{}",
+        pk.vk.cs.shuffles.0.len(),
+        shuffle_groups.len()
+    ));
     let shuffles: Vec<Vec<shuffle::prover::Compressed<C>>> = instance
         .iter()
         .zip(advice.iter())
         .map(|(instance, advice)| -> Vec<_> {
-            pk.vk
-                .cs
-                .shuffles
+            shuffle_groups
                 .par_iter()
                 .map(|shuffle| {
                     shuffle
@@ -965,14 +968,17 @@ pub fn create_proof_from_witness<
     });
     end_timer!(timer);
 
-    let timer = start_timer!(|| format!("shuffles {}", pk.vk.cs.shuffles.len()));
+    let shuffle_groups = pk.vk.cs.shuffles.group(pk.vk.cs.degree());
+    let timer = start_timer!(|| format!(
+        "total shuffles {}, groups {}",
+        pk.vk.cs.shuffles.0.len(),
+        shuffle_groups.len()
+    ));
     let shuffles: Vec<Vec<shuffle::prover::Compressed<C>>> = instance
         .iter()
         .zip(advice.iter())
         .map(|(instance, advice)| -> Vec<_> {
-            pk.vk
-                .cs
-                .shuffles
+            shuffle_groups
                 .par_iter()
                 .map(|shuffle| {
                     shuffle

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -32,7 +32,6 @@ use super::{
 };
 use crate::arithmetic::eval_polynomial_st;
 use crate::plonk::lookup::prover::Permuted;
-use crate::plonk::ChallengeDelta;
 use crate::{
     arithmetic::{eval_polynomial, BaseExt, CurveAffine, FieldExt},
     plonk::Assigned,
@@ -348,8 +347,6 @@ pub fn create_proof_ext<
     let beta: ChallengeBeta<_> = transcript.squeeze_challenge_scalar();
     // Sample gamma challenge
     let gamma: ChallengeGamma<_> = transcript.squeeze_challenge_scalar();
-    // Sample delta challenge
-    let delta: ChallengeDelta<_> = transcript.squeeze_challenge_scalar();
 
     let (lookups, shuffles, permutations) = std::thread::scope(|s| {
         let permutations = s.spawn(|| {
@@ -438,11 +435,7 @@ pub fn create_proof_ext<
             .map(|shuffles| {
                 shuffles
                     .into_par_iter()
-                    .map(|shuffle| {
-                        shuffle
-                            .commit_product(pk, params, beta, gamma, delta)
-                            .unwrap()
-                    })
+                    .map(|shuffle| shuffle.commit_product(pk, params, beta).unwrap())
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
@@ -601,7 +594,6 @@ pub fn create_proof_ext<
         *y,
         *beta,
         *gamma,
-        *delta,
         *theta,
         &lookups,
         &shuffles,
@@ -616,7 +608,6 @@ pub fn create_proof_ext<
         *y,
         *beta,
         *gamma,
-        *delta,
         *theta,
         &lookups,
         &shuffles,
@@ -1011,8 +1002,6 @@ pub fn create_proof_from_witness<
     let beta: ChallengeBeta<_> = transcript.squeeze_challenge_scalar();
     // Sample gamma challenge
     let gamma: ChallengeGamma<_> = transcript.squeeze_challenge_scalar();
-    // Sample delta challenge
-    let delta: ChallengeDelta<_> = transcript.squeeze_challenge_scalar();
 
     let (lookups, shuffles, permutations) = std::thread::scope(|s| {
         let permutations = s.spawn(|| {
@@ -1101,11 +1090,7 @@ pub fn create_proof_from_witness<
             .map(|shuffles| {
                 shuffles
                     .into_par_iter()
-                    .map(|shuffle| {
-                        shuffle
-                            .commit_product(pk, params, beta, gamma, delta)
-                            .unwrap()
-                    })
+                    .map(|shuffle| shuffle.commit_product(pk, params, beta).unwrap())
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
@@ -1264,7 +1249,6 @@ pub fn create_proof_from_witness<
         *y,
         *beta,
         *gamma,
-        *delta,
         *theta,
         &lookups,
         &shuffles,
@@ -1279,7 +1263,6 @@ pub fn create_proof_from_witness<
         *y,
         *beta,
         *gamma,
-        *delta,
         *theta,
         &lookups,
         &shuffles,

--- a/halo2_proofs/src/plonk/shuffle.rs
+++ b/halo2_proofs/src/plonk/shuffle.rs
@@ -5,23 +5,63 @@ pub(crate) mod prover;
 pub(crate) mod verifier;
 
 #[derive(Clone, Debug)]
-pub struct Argument<F: Field> {
+pub struct Argument<F: Field>(pub Vec<ArgumentElement<F>>);
+
+impl<F: Field> Argument<F> {
+    pub(crate) fn new() -> Self {
+        Argument(vec![])
+    }
+
+    //TODO: implement optimal algorithm to find minimum group sets
+    pub fn group(&self, degree: usize) -> Vec<ArgumentGroup<F>> {
+        assert!(degree > 2, "Invalid degree");
+        //(1 - (l_last + l_blind)) * z(\omega X) has 2 degree
+        let (low, high): (Vec<ArgumentElement<F>>, Vec<ArgumentElement<F>>) =
+            self.0.iter().cloned().partition(|s| s.degree() == 1);
+        let mut group: Vec<ArgumentGroup<F>> = low
+            .chunks(degree - 2)
+            .map(|v| ArgumentGroup(v.to_vec()))
+            .collect();
+        group.extend(high.into_iter().map(|v| ArgumentGroup(vec![v])));
+        group
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ArgumentGroup<F: Field>(pub Vec<ArgumentElement<F>>);
+
+#[derive(Clone, Debug)]
+pub struct ArgumentElement<F: Field> {
     pub name: &'static str,
     pub input_expressions: Vec<Expression<F>>,
     pub shuffle_expressions: Vec<Expression<F>>,
 }
 
-impl<F: Field> Argument<F> {
+impl<F: Field> ArgumentElement<F> {
     /// Constructs a new shuffle lookup argument.
     ///
     /// `shuffle_map` is a sequence of `(input, shuffle)` tuples.
     pub fn new(name: &'static str, shuffle_map: Vec<(Expression<F>, Expression<F>)>) -> Self {
         let (input_expressions, shuffle_expressions) = shuffle_map.into_iter().unzip();
-        Argument {
+        ArgumentElement {
             name,
             input_expressions,
             shuffle_expressions,
         }
+    }
+
+    //get expressions max degree
+    pub(crate) fn degree(&self) -> usize {
+        assert_eq!(self.input_expressions.len(), self.shuffle_expressions.len());
+        let mut input_degree = 1;
+        for expr in self.input_expressions.iter() {
+            input_degree = std::cmp::max(input_degree, expr.degree());
+        }
+        let mut shuffle_degree = 1;
+        for expr in self.shuffle_expressions.iter() {
+            shuffle_degree = std::cmp::max(shuffle_degree, expr.degree());
+        }
+        std::cmp::max(shuffle_degree, input_degree)
     }
 
     pub(crate) fn required_degree(&self) -> usize {

--- a/halo2_proofs/src/plonk/shuffle.rs
+++ b/halo2_proofs/src/plonk/shuffle.rs
@@ -1,0 +1,52 @@
+use super::circuit::Expression;
+use ff::Field;
+
+pub(crate) mod prover;
+pub(crate) mod verifier;
+
+#[derive(Clone, Debug)]
+pub struct Argument<F: Field> {
+    pub name: &'static str,
+    pub input_expressions: Vec<Expression<F>>,
+    pub shuffle_expressions: Vec<Expression<F>>,
+}
+
+impl<F: Field> Argument<F> {
+    /// Constructs a new shuffle lookup argument.
+    ///
+    /// `shuffle_map` is a sequence of `(input, shuffle)` tuples.
+    pub fn new(name: &'static str, shuffle_map: Vec<(Expression<F>, Expression<F>)>) -> Self {
+        let (input_expressions, shuffle_expressions) = shuffle_map.into_iter().unzip();
+        Argument {
+            name,
+            input_expressions,
+            shuffle_expressions,
+        }
+    }
+
+    pub(crate) fn required_degree(&self) -> usize {
+        assert_eq!(self.input_expressions.len(), self.shuffle_expressions.len());
+
+        //
+        // The "last" value in the permutation poly should be a boolean, for
+        // completeness and soundness.
+        // degree 3:
+        // l_last(X) * (z(X)^2 - z(X)) = 0
+        //
+        // Enable the permutation argument for only the rows involved.
+        // degree 2+input or 2+shuffle degree:
+        // (1 - (l_last(X) + l_blind(X))) * (
+        //   z(\omega X) (s(X) + \gamma) - z(X) (a(X) + \gamma)
+        // ) = 0
+
+        let mut input_degree = 1;
+        for expr in self.input_expressions.iter() {
+            input_degree = std::cmp::max(input_degree, expr.degree());
+        }
+        let mut shuffle_degree = 1;
+        for expr in self.shuffle_expressions.iter() {
+            shuffle_degree = std::cmp::max(shuffle_degree, expr.degree());
+        }
+        std::cmp::max(2 + shuffle_degree, 2 + input_degree)
+    }
+}

--- a/halo2_proofs/src/plonk/shuffle.rs
+++ b/halo2_proofs/src/plonk/shuffle.rs
@@ -26,19 +26,8 @@ impl<F: Field> Argument<F> {
 
     pub(crate) fn required_degree(&self) -> usize {
         assert_eq!(self.input_expressions.len(), self.shuffle_expressions.len());
-
-        //
-        // The "last" value in the permutation poly should be a boolean, for
-        // completeness and soundness.
-        // degree 3:
-        // l_last(X) * (z(X)^2 - z(X)) = 0
-        //
-        // Enable the permutation argument for only the rows involved.
         // degree 2+input or 2+shuffle degree:
-        // (1 - (l_last(X) + l_blind(X))) * (
-        //   z(\omega X) (s(X) + \gamma) - z(X) (a(X) + \gamma)
-        // ) = 0
-
+        // (1 - (l_last + l_blind)) (z(\omega X) (s(X) + \gamma) - z(X) (a(X) + \gamma))
         let mut input_degree = 1;
         for expr in self.input_expressions.iter() {
             input_degree = std::cmp::max(input_degree, expr.degree());

--- a/halo2_proofs/src/plonk/shuffle.rs
+++ b/halo2_proofs/src/plonk/shuffle.rs
@@ -79,7 +79,6 @@ pub struct ArgumentElement<F: Field> {
 
 impl<F: Field> ArgumentElement<F> {
     /// Constructs a new shuffle lookup argument.
-    ///
     /// `shuffle_map` is a sequence of `(input, shuffle)` tuples.
     pub fn new(name: &'static str, shuffle_map: Vec<(Expression<F>, Expression<F>)>) -> Self {
         let (input_expressions, shuffle_expressions) = shuffle_map.into_iter().unzip();
@@ -104,10 +103,11 @@ impl<F: Field> ArgumentElement<F> {
         std::cmp::max(shuffle_degree, input_degree)
     }
 
+    //get shuffle gate's max degree
     pub(crate) fn required_degree(&self) -> usize {
         assert_eq!(self.input_expressions.len(), self.shuffle_expressions.len());
         // degree 2+input or 2+shuffle degree:
-        // (1 - (l_last + l_blind)) (z(\omega X) (s(X) + \gamma) - z(X) (a(X) + \gamma))
+        // (1 - (l_last + l_blind)) (z(\omega X) (s1(X) + \beta) - z(X) (a(X) + \beta))
         let mut input_degree = 1;
         for expr in self.input_expressions.iter() {
             input_degree = std::cmp::max(input_degree, expr.degree());

--- a/halo2_proofs/src/plonk/shuffle/prover.rs
+++ b/halo2_proofs/src/plonk/shuffle/prover.rs
@@ -1,0 +1,261 @@
+use super::super::{
+    circuit::Expression, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, Error,
+    ProvingKey,
+};
+use super::Argument;
+use crate::arithmetic::{batch_invert, eval_polynomial_st};
+use crate::plonk::evaluation::{evaluate, evaluate_with_theta};
+use crate::poly::Basis;
+use crate::{
+    arithmetic::{eval_polynomial, parallelize, BaseExt, CurveAffine, FieldExt},
+    poly::{
+        commitment::Params, multiopen::ProverQuery, Coeff, EvaluationDomain, ExtendedLagrangeCoeff,
+        LagrangeCoeff, Polynomial, Rotation,
+    },
+    transcript::{EncodedChallenge, TranscriptWrite},
+};
+use ark_std::UniformRand;
+use ark_std::{end_timer, start_timer};
+use ff::PrimeField;
+use group::{
+    ff::{BatchInvert, Field},
+    Curve,
+};
+use rand_core::RngCore;
+use rayon::prelude::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
+    IntoParallelRefMutIterator, ParallelIterator, ParallelSliceMut,
+};
+use std::any::TypeId;
+use std::convert::TryInto;
+use std::num::ParseIntError;
+use std::ops::Index;
+use std::{
+    collections::BTreeMap,
+    iter,
+    ops::{Mul, MulAssign},
+};
+
+#[derive(Debug)]
+pub(in crate::plonk) struct Compressed<C: CurveAffine> {
+    input_expression: Polynomial<C::Scalar, LagrangeCoeff>,
+    shuffle_expression: Polynomial<C::Scalar, LagrangeCoeff>,
+}
+
+#[derive(Debug)]
+pub(in crate::plonk) struct Committed<C: CurveAffine> {
+    pub(in crate::plonk) product_poly: Polynomial<C::Scalar, Coeff>,
+}
+
+pub(in crate::plonk) struct Evaluated<C: CurveAffine> {
+    constructed: Committed<C>,
+}
+
+impl<F: FieldExt> Argument<F> {
+    /// Given a Lookup with input expressions [A_0, A_1, ..., A_{m-1}] and shuffle expressions
+    /// [S_0, S_1, ..., S_{m-1}], this method
+    /// - constructs A_compressed = \theta^{m-1} A_0 + theta^{m-2} A_1 + ... + \theta A_{m-2} + A_{m-1}
+    ///   and S_compressed = \theta^{m-1} S_0 + theta^{m-2} S_1 + ... + \theta S_{m-2} + S_{m-1},
+    pub(in crate::plonk) fn compress<'a, C>(
+        &self,
+        pk: &ProvingKey<C>,
+        params: &Params<C>,
+        theta: ChallengeTheta<C>,
+        advice_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
+        fixed_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
+        instance_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
+    ) -> Result<Compressed<C>, Error>
+    where
+        C: CurveAffine<ScalarExt = F>,
+        C::Curve: Mul<F, Output = C::Curve> + MulAssign<F>,
+    {
+        // Closure to get values of expressions and compress them
+        let compress_expressions = |expressions: &[Expression<C::Scalar>]| {
+            pk.vk.domain.lagrange_from_vec(evaluate_with_theta(
+                expressions,
+                params.n as usize,
+                1,
+                fixed_values,
+                advice_values,
+                instance_values,
+                *theta,
+            ))
+        };
+        println!(
+            "input_expressions: {:?},len={}",
+            self.input_expressions,
+            self.input_expressions.len()
+        );
+        println!(
+            "shuffle_expressions={:?},len={}",
+            self.shuffle_expressions,
+            self.shuffle_expressions.len()
+        );
+        // Get values of input expressions involved in the lookup and compress them
+        let input_expression = compress_expressions(&self.input_expressions);
+
+        // Get values of table expressions involved in the lookup and compress them
+        let shuffle_expression = compress_expressions(&self.shuffle_expressions);
+        println!("input_expression.val: {:?}", input_expression);
+        println!("shuffle_expression.val={:?}", shuffle_expression);
+        Ok(Compressed {
+            input_expression,
+            shuffle_expression,
+        })
+    }
+}
+
+impl<C: CurveAffine> Compressed<C> {
+    /// Given a Lookup with input expressions, table expressions, and the permuted
+    /// input expression and permuted table expression, this method constructs the
+    /// grand product polynomial over the lookup. The grand product polynomial
+    /// is used to populate the Product<C> struct. The Product<C> struct is
+    /// added to the Lookup and finally returned by the method.
+    pub(in crate::plonk) fn commit_product(
+        self,
+        pk: &ProvingKey<C>,
+        params: &Params<C>,
+        gamma: ChallengeGamma<C>,
+    ) -> Result<Vec<C::Scalar>, Error> {
+        let blinding_factors = pk.vk.cs.blinding_factors();
+
+        // Goal is to compute the products of fractions
+        //
+        // Numerator:   (\theta^{m-1} a_0(\omega^i) + \theta^{m-2} a_1(\omega^i) + ... + \theta a_{m-2}(\omega^i) + a_{m-1}(\omega^i) + \gamma)
+        // Denominator: (\theta^{m-1} s_0(\omega^i) + \theta^{m-2} s_1(\omega^i) + ... + \theta s_{m-2}(\omega^i) + s_{m-1}(\omega^i) + \gamma)
+        //
+        // where a_j(X) is the jth input expression in this lookup,
+        // s_j(X) is the jth table expression in this lookup,
+        // and i is the ith row of the expression.
+        let mut shuffle_product = vec![C::Scalar::zero(); params.n as usize];
+        // println!("gamma: {:?}",gamma);
+        #[cfg(not(feature = "cuda"))]
+        {
+            // Denominator uses the permuted input expression and permuted table expression
+            // * (\theta^{m-1} s_0(\omega^i) + \theta^{m-2} s_1(\omega^i) + ... + \theta s_{m-2}(\omega^i) + s_{m-1}(\omega^i) + \gamma)
+            parallelize(&mut shuffle_product, |shuffle_product, start| {
+                for (shuffle_product, shuffle_value) in shuffle_product
+                    .iter_mut()
+                    .zip(self.shuffle_expression[start..].iter())
+                {
+                    *shuffle_product = *gamma + shuffle_value;
+                }
+            });
+
+            // Batch invert to obtain the denominators for the lookup product
+            // polynomials
+            batch_invert(&mut shuffle_product);
+
+            // Finish the computation of the entire fraction by computing the numerators
+            // (\theta^{m-1} a_0(\omega^i) + \theta^{m-2} a_1(\omega^i) + ... + \theta a_{m-2}(\omega^i) + a_{m-1}(\omega^i) + \beta)
+            parallelize(&mut shuffle_product, |product, start| {
+                for (i, product) in product.iter_mut().enumerate() {
+                    let i = i + start;
+                    *product *= &(self.input_expression[i] + &*gamma);
+                }
+            });
+        }
+
+        // The product vector is a vector of products of fractions of the form
+        //
+        // Numerator: (\theta^{m-1} a_0(\omega^i) + \theta^{m-2} a_1(\omega^i) + ... + \theta a_{m-2}(\omega^i) + a_{m-1}(\omega^i) + \beta)
+        //            * (\theta^{m-1} s_0(\omega^i) + \theta^{m-2} s_1(\omega^i) + ... + \theta s_{m-2}(\omega^i) + s_{m-1}(\omega^i) + \gamma)
+        // Denominator: (a'(\omega^i) + \beta) (s'(\omega^i) + \gamma)
+        //
+        // where there are m input expressions and m table expressions,
+        // a_j(\omega^i) is the jth input expression in this lookup,
+        // a'j(\omega^i) is the permuted input expression,
+        // s_j(\omega^i) is the jth table expression in this lookup,
+        // s'(\omega^i) is the permuted table expression,
+        // and i is the ith row of the expression.
+        // Compute the evaluations of the lookup product polynomial
+        // over our domain, starting with z[0] = 1
+        let z = iter::once(C::Scalar::one())
+            .chain(shuffle_product)
+            .scan(C::Scalar::one(), |state, cur| {
+                *state *= &cur;
+                Some(*state)
+            })
+            // Take all rows including the "last" row which should
+            // be a boolean (and ideally 1, else soundness is broken)
+            .take(params.n as usize - blinding_factors)
+            .collect::<Vec<_>>();
+        println!("z.len={}", z.len());
+
+        #[cfg(feature = "sanity-checks")]
+        // This test works only with intermediate representations in this method.
+        // It can be used for debugging purposes.
+        {
+            // While in Lagrange basis, check that product is correctly constructed
+            let u = (params.n as usize) - (blinding_factors + 1);
+            println!("n={},blinding={},z={:?}", params.n, blinding_factors, z);
+            // l_0(X) * (1 - z(X)) = 0
+            assert_eq!(z[0], C::Scalar::one());
+
+            // z(\omega X) (a'(X) + \beta) (s'(X) + \gamma)
+            // - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
+            for i in 0..u {
+                let mut left = z[i + 1];
+                let mut table_term = self.shuffle_expression[i];
+                table_term += &(*gamma);
+                left *= &(table_term);
+
+                let mut right = z[i];
+                let mut input_term = self.input_expression[i];
+                input_term += &(*gamma);
+                right *= &(input_term);
+
+                assert_eq!(left, right);
+            }
+
+            // l_last(X) * (z(X)^2 - z(X)) = 0
+            // Assertion will fail only when soundness is broken, in which
+            // case this z[u] value will be zero. (bad!)
+            assert_eq!(z[u], C::Scalar::one());
+        }
+
+        Ok(z)
+    }
+}
+
+impl<C: CurveAffine> Committed<C> {
+    pub(in crate::plonk) fn evaluate(
+        self,
+        pk: &ProvingKey<C>,
+        x: ChallengeX<C>,
+    ) -> (Evaluated<C>, Vec<C::ScalarExt>) {
+        let domain = &pk.vk.domain;
+        let x_next = domain.rotate_omega(*x, Rotation::next());
+
+        let evals = vec![(&self.product_poly, *x), (&self.product_poly, x_next)]
+            .into_par_iter()
+            .map(|(a, b)| eval_polynomial_st(a, b))
+            .collect();
+
+        (Evaluated { constructed: self }, evals)
+    }
+}
+
+impl<C: CurveAffine> Evaluated<C> {
+    pub(in crate::plonk) fn open<'a>(
+        &'a self,
+        pk: &'a ProvingKey<C>,
+        x: ChallengeX<C>,
+    ) -> impl Iterator<Item = ProverQuery<'a, C>> + Clone {
+        let x_next = pk.vk.domain.rotate_omega(*x, Rotation::next());
+
+        iter::empty()
+            // Open lookup product commitments at x
+            .chain(Some(ProverQuery {
+                point: *x,
+                rotation: Rotation::cur(),
+                poly: &self.constructed.product_poly,
+            }))
+            // Open lookup product commitments at x_next
+            .chain(Some(ProverQuery {
+                point: x_next,
+                rotation: Rotation::next(),
+                poly: &self.constructed.product_poly,
+            }))
+    }
+}

--- a/halo2_proofs/src/plonk/shuffle/prover.rs
+++ b/halo2_proofs/src/plonk/shuffle/prover.rs
@@ -81,23 +81,12 @@ impl<F: FieldExt> Argument<F> {
                 *theta,
             ))
         };
-        println!(
-            "input_expressions: {:?},len={}",
-            self.input_expressions,
-            self.input_expressions.len()
-        );
-        println!(
-            "shuffle_expressions={:?},len={}",
-            self.shuffle_expressions,
-            self.shuffle_expressions.len()
-        );
+
         // Get values of input expressions involved in the lookup and compress them
         let input_expression = compress_expressions(&self.input_expressions);
 
         // Get values of table expressions involved in the lookup and compress them
         let shuffle_expression = compress_expressions(&self.shuffle_expressions);
-        println!("input_expression.val: {:?}", input_expression);
-        println!("shuffle_expression.val={:?}", shuffle_expression);
         Ok(Compressed {
             input_expression,
             shuffle_expression,
@@ -128,8 +117,7 @@ impl<C: CurveAffine> Compressed<C> {
         // s_j(X) is the jth table expression in this lookup,
         // and i is the ith row of the expression.
         let mut shuffle_product = vec![C::Scalar::zero(); params.n as usize];
-        // println!("gamma: {:?}",gamma);
-        #[cfg(not(feature = "cuda"))]
+         // #[cfg(not(feature = "cuda"))]
         {
             // Denominator uses the permuted input expression and permuted table expression
             // * (\theta^{m-1} s_0(\omega^i) + \theta^{m-2} s_1(\omega^i) + ... + \theta s_{m-2}(\omega^i) + s_{m-1}(\omega^i) + \gamma)
@@ -180,7 +168,6 @@ impl<C: CurveAffine> Compressed<C> {
             // be a boolean (and ideally 1, else soundness is broken)
             .take(params.n as usize - blinding_factors)
             .collect::<Vec<_>>();
-        println!("z.len={}", z.len());
 
         #[cfg(feature = "sanity-checks")]
         // This test works only with intermediate representations in this method.
@@ -188,10 +175,8 @@ impl<C: CurveAffine> Compressed<C> {
         {
             // While in Lagrange basis, check that product is correctly constructed
             let u = (params.n as usize) - (blinding_factors + 1);
-            println!("n={},blinding={},z={:?}", params.n, blinding_factors, z);
             // l_0(X) * (1 - z(X)) = 0
             assert_eq!(z[0], C::Scalar::one());
-
             // z(\omega X) (a'(X) + \beta) (s'(X) + \gamma)
             // - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
             for i in 0..u {

--- a/halo2_proofs/src/plonk/shuffle/verifier.rs
+++ b/halo2_proofs/src/plonk/shuffle/verifier.rs
@@ -1,0 +1,143 @@
+use std::iter;
+
+use super::super::{
+    circuit::Expression, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX,
+};
+use super::Argument;
+use crate::{
+    arithmetic::{CurveAffine, FieldExt},
+    plonk::{Error, VerifyingKey},
+    poly::{multiopen::VerifierQuery, Rotation},
+    transcript::{EncodedChallenge, TranscriptRead},
+};
+use ff::Field;
+
+#[derive(Debug)]
+pub struct Committed<C: CurveAffine> {
+    pub product_commitment: C,
+}
+
+#[derive(Debug)]
+pub struct Evaluated<C: CurveAffine> {
+    pub committed: Committed<C>,
+    pub product_eval: C::Scalar,
+    pub product_next_eval: C::Scalar,
+}
+
+impl<F: FieldExt> Argument<F> {
+    pub fn read_product_commitment<
+        C: CurveAffine,
+        E: EncodedChallenge<C>,
+        T: TranscriptRead<C, E>,
+    >(
+        &self,
+        transcript: &mut T,
+    ) -> Result<Committed<C>, Error> {
+        let product_commitment = transcript.read_point()?;
+
+        Ok(Committed { product_commitment })
+    }
+}
+
+impl<C: CurveAffine> Committed<C> {
+    pub fn evaluate<E: EncodedChallenge<C>, T: TranscriptRead<C, E>>(
+        self,
+        transcript: &mut T,
+    ) -> Result<Evaluated<C>, Error> {
+        let product_eval = transcript.read_scalar()?;
+        let product_next_eval = transcript.read_scalar()?;
+
+        Ok(Evaluated {
+            committed: self,
+            product_eval,
+            product_next_eval,
+        })
+    }
+}
+
+impl<C: CurveAffine> Evaluated<C> {
+    pub(in crate::plonk) fn expressions<'a>(
+        &'a self,
+        l_0: C::Scalar,
+        l_last: C::Scalar,
+        l_blind: C::Scalar,
+        argument: &'a Argument<C::Scalar>,
+        theta: ChallengeTheta<C>,
+        gamma: ChallengeGamma<C>,
+        advice_evals: &[C::Scalar],
+        fixed_evals: &[C::Scalar],
+        instance_evals: &[C::Scalar],
+    ) -> impl Iterator<Item = C::Scalar> + 'a {
+        println!("expression fixed_evals={:?}", fixed_evals);
+        let active_rows = C::Scalar::one() - (l_last + l_blind);
+        let product_expression = || {
+            // z(\omega X) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \beta)
+            // - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta)
+            let compress_expressions = |expressions: &[Expression<C::Scalar>]| {
+                expressions
+                    .iter()
+                    .map(|expression| {
+                        expression.evaluate(
+                            &|scalar| scalar,
+                            &|_| panic!("virtual selectors are removed during optimization"),
+                            &|index, _, _| fixed_evals[index],
+                            &|index, _, _| advice_evals[index],
+                            &|index, _, _| instance_evals[index],
+                            &|a| -a,
+                            &|a, b| a + &b,
+                            &|a, b| a() * &b(),
+                            &|a, scalar| a * &scalar,
+                        )
+                    })
+                    .fold(C::Scalar::zero(), |acc, eval| acc * &*theta + &eval)
+            };
+            let left = self.product_next_eval
+                * &(compress_expressions(&argument.shuffle_expressions) + &*gamma);
+            let right =
+                self.product_eval * &(compress_expressions(&argument.input_expressions) + &*gamma);
+            // println!("vk.left={:?} vk.right={:?},l0={:?},last={:?},lblind={:?}", left, right,l_0,l_last,l_blind);
+            active_rows * &(left - &right)
+        };
+
+        std::iter::empty()
+            .chain(
+                // l_0(X) * (1 - z'(X)) = 0
+                Some(l_0 * &(C::Scalar::one() - &self.product_eval)),
+            )
+            .chain(
+                // l_last(X) * (z(X)^2 - z(X)) = 0
+                Some(l_last * &(self.product_eval.square() - &self.product_eval)),
+            )
+            .chain(
+                // (1 - (l_last(X) + l_blind(X))) * (
+                //   z(\omega X) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \beta)
+                //   - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta)
+                // ) = 0
+                Some(product_expression()),
+            )
+    }
+
+    pub(in crate::plonk) fn queries<'r>(
+        &'r self,
+        vk: &'r VerifyingKey<C>,
+        x: ChallengeX<C>,
+    ) -> impl Iterator<Item = VerifierQuery<'r, C>> + Clone {
+        let x_next = vk.domain.rotate_omega(*x, Rotation::next());
+
+        iter::empty()
+            // Open lookup product commitment at x
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.committed.product_commitment,
+                *x,
+                Rotation::cur(),
+                self.product_eval,
+            )))
+            // Open lookup product commitment at \omega x
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.committed.product_commitment,
+                x_next,
+                Rotation::next(),
+                self.product_next_eval,
+            )))
+    }
+}

--- a/halo2_proofs/src/plonk/shuffle/verifier.rs
+++ b/halo2_proofs/src/plonk/shuffle/verifier.rs
@@ -68,7 +68,6 @@ impl<C: CurveAffine> Evaluated<C> {
         fixed_evals: &[C::Scalar],
         instance_evals: &[C::Scalar],
     ) -> impl Iterator<Item = C::Scalar> + 'a {
-        println!("expression fixed_evals={:?}", fixed_evals);
         let active_rows = C::Scalar::one() - (l_last + l_blind);
         let product_expression = || {
             // z(\omega X) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \beta)
@@ -95,8 +94,7 @@ impl<C: CurveAffine> Evaluated<C> {
                 * &(compress_expressions(&argument.shuffle_expressions) + &*gamma);
             let right =
                 self.product_eval * &(compress_expressions(&argument.input_expressions) + &*gamma);
-            // println!("vk.left={:?} vk.right={:?},l0={:?},last={:?},lblind={:?}", left, right,l_0,l_last,l_blind);
-            active_rows * &(left - &right)
+             (left - &right) * &active_rows
         };
 
         std::iter::empty()

--- a/halo2_proofs/src/plonk/shuffle/verifier.rs
+++ b/halo2_proofs/src/plonk/shuffle/verifier.rs
@@ -70,8 +70,8 @@ impl<C: CurveAffine> Evaluated<C> {
     ) -> impl Iterator<Item = C::Scalar> + 'a {
         let active_rows = C::Scalar::one() - (l_last + l_blind);
         let product_expression = || {
-            // z(\omega X) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \beta)
-            // - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta)
+            // z(\omega X) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
+            // - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \gamma)
             let compress_expressions = |expressions: &[Expression<C::Scalar>]| {
                 expressions
                     .iter()
@@ -94,7 +94,7 @@ impl<C: CurveAffine> Evaluated<C> {
                 * &(compress_expressions(&argument.shuffle_expressions) + &*gamma);
             let right =
                 self.product_eval * &(compress_expressions(&argument.input_expressions) + &*gamma);
-             (left - &right) * &active_rows
+            (left - &right) * &active_rows
         };
 
         std::iter::empty()
@@ -107,10 +107,7 @@ impl<C: CurveAffine> Evaluated<C> {
                 Some(l_last * &(self.product_eval.square() - &self.product_eval)),
             )
             .chain(
-                // (1 - (l_last(X) + l_blind(X))) * (
-                //   z(\omega X) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \beta)
-                //   - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta)
-                // ) = 0
+                // (1 - (l_last(X) + l_blind(X))) * ( z(\omega X) (s(X) + \gamma) - z(X) (a(X) + \gamma))
                 Some(product_expression()),
             )
     }

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -278,7 +278,6 @@ pub fn verify_proof_ext<
                 .collect::<Result<Vec<_>, _>>()
         })
         .collect::<Result<Vec<_>, _>>()?;
-    println!("shuffles_evaluated={:?}", shuffles_evaluated);
     // This check ensures the circuit is satisfied so long as the polynomial
     // commitments open to the correct values.
     let vanishing = {

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use std::ops::Mul;
 
 use super::{
-    vanishing, ChallengeBeta, ChallengeDelta, ChallengeGamma, ChallengeTheta, ChallengeX,
-    ChallengeY, Error, VerifyingKey,
+    vanishing, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error,
+    VerifyingKey,
 };
 use crate::arithmetic::{BaseExt, CurveAffine, FieldExt, MultiMillerLoop};
 
@@ -201,9 +201,6 @@ pub fn verify_proof_ext<
     // Sample gamma challenge
     let gamma: ChallengeGamma<_> = transcript.squeeze_challenge_scalar();
 
-    // Sample delta challenge
-    let delta: ChallengeDelta<_> = transcript.squeeze_challenge_scalar();
-
     let permutations_committed = (0..num_proofs)
         .map(|_| {
             // Hash each permutation product commitment
@@ -372,8 +369,6 @@ pub fn verify_proof_ext<
                                     argument,
                                     theta,
                                     beta,
-                                    gamma,
-                                    delta,
                                     advice_evals,
                                     fixed_evals,
                                     instance_evals,

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -224,6 +224,7 @@ pub fn verify_proof_ext<
             // Hash each lookup permuted commitment
             vk.cs
                 .shuffles
+                .group(vk.cs.degree())
                 .iter()
                 .map(|argument| argument.read_product_commitment(transcript))
                 .collect::<Result<Vec<_>, _>>()
@@ -295,6 +296,7 @@ pub fn verify_proof_ext<
             .fold(C::Scalar::zero(), |acc, eval| acc + eval);
         let l_0 = l_evals[1 + blinding_factors];
 
+        let shuffle_groups = vk.cs.shuffles.group(vk.cs.degree());
         // Compute the expected value of h(x)
         let expressions = advice_evals
             .iter()
@@ -358,7 +360,7 @@ pub fn verify_proof_ext<
                                 })
                                 .into_iter(),
                         )
-                        .chain(shuffles.iter().zip(vk.cs.shuffles.iter()).flat_map(
+                        .chain(shuffles.iter().zip(shuffle_groups.iter()).flat_map(
                             move |(s, argument)| {
                                 s.expressions(
                                     l_0,

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use std::ops::Mul;
 
 use super::{
-    vanishing, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error,
-    VerifyingKey,
+    vanishing, ChallengeBeta, ChallengeDelta, ChallengeGamma, ChallengeTheta, ChallengeX,
+    ChallengeY, Error, VerifyingKey,
 };
 use crate::arithmetic::{BaseExt, CurveAffine, FieldExt, MultiMillerLoop};
 
@@ -201,6 +201,9 @@ pub fn verify_proof_ext<
     // Sample gamma challenge
     let gamma: ChallengeGamma<_> = transcript.squeeze_challenge_scalar();
 
+    // Sample delta challenge
+    let delta: ChallengeDelta<_> = transcript.squeeze_challenge_scalar();
+
     let permutations_committed = (0..num_proofs)
         .map(|_| {
             // Hash each permutation product commitment
@@ -368,7 +371,9 @@ pub fn verify_proof_ext<
                                     l_blind,
                                     argument,
                                     theta,
+                                    beta,
                                     gamma,
+                                    delta,
                                     advice_evals,
                                     fixed_evals,
                                     instance_evals,

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -439,7 +439,7 @@ fn plonk_api() {
     };
     assert_eq!(prover.verify(), Ok(()));
 
-    for _ in 0..10 {
+    for _ in 0..1 {
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
         // Create a proof
         create_proof(
@@ -471,44 +471,44 @@ fn plonk_api() {
         // Test batch-verifier strategy.
         //
 
-        {
-            let strategy = BatchVerifier::new(&params_verifier, OsRng);
-
-            // First proof.
-            let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-            let strategy = verify_proof(
-                &params_verifier,
-                pk.get_vk(),
-                strategy,
-                &[&[&pubinputs[..]], &[&pubinputs[..]]],
-                &mut transcript,
-            )
-            .unwrap();
-
-            // Write and then read the verification key in between (to check round-trip
-            // serialization).
-            // TODO: Figure out whether https://github.com/zcash/halo2/issues/449 should
-            // be caught by this, or if it is caused by downstream changes to halo2.
-            let mut vk_buffer = vec![];
-            pk.get_vk().write(&mut vk_buffer).unwrap();
-            let vk =
-                VerifyingKey::<G1Affine>::read::<_, MyCircuit<Fp>>(&mut &vk_buffer[..], &params)
-                    .unwrap();
-
-            // "Second" proof (just the first proof again).
-            let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-            let strategy = verify_proof(
-                &params_verifier,
-                &vk,
-                strategy,
-                &[&[&pubinputs[..]], &[&pubinputs[..]]],
-                &mut transcript,
-            )
-            .unwrap();
-
-            // Check the batch.
-            assert!(strategy.finalize());
-        }
+        // {
+        //     let strategy = BatchVerifier::new(&params_verifier, OsRng);
+        //
+        //     // First proof.
+        //     let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+        //     let strategy = verify_proof(
+        //         &params_verifier,
+        //         pk.get_vk(),
+        //         strategy,
+        //         &[&[&pubinputs[..]], &[&pubinputs[..]]],
+        //         &mut transcript,
+        //     )
+        //     .unwrap();
+        //
+        //     // Write and then read the verification key in between (to check round-trip
+        //     // serialization).
+        //     // TODO: Figure out whether https://github.com/zcash/halo2/issues/449 should
+        //     // be caught by this, or if it is caused by downstream changes to halo2.
+        //     let mut vk_buffer = vec![];
+        //     pk.get_vk().write(&mut vk_buffer).unwrap();
+        //     let vk =
+        //         VerifyingKey::<G1Affine>::read::<_, MyCircuit<Fp>>(&mut &vk_buffer[..], &params)
+        //             .unwrap();
+        //
+        //     // "Second" proof (just the first proof again).
+        //     let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+        //     let strategy = verify_proof(
+        //         &params_verifier,
+        //         &vk,
+        //         strategy,
+        //         &[&[&pubinputs[..]], &[&pubinputs[..]]],
+        //         &mut transcript,
+        //     )
+        //     .unwrap();
+        //
+        //     // Check the batch.
+        //     assert!(strategy.finalize());
+        // }
     }
 }
 */

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -439,7 +439,7 @@ fn plonk_api() {
     };
     assert_eq!(prover.verify(), Ok(()));
 
-    for _ in 0..1 {
+    for _ in 0..10 {
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
         // Create a proof
         create_proof(
@@ -471,44 +471,44 @@ fn plonk_api() {
         // Test batch-verifier strategy.
         //
 
-        // {
-        //     let strategy = BatchVerifier::new(&params_verifier, OsRng);
-        //
-        //     // First proof.
-        //     let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-        //     let strategy = verify_proof(
-        //         &params_verifier,
-        //         pk.get_vk(),
-        //         strategy,
-        //         &[&[&pubinputs[..]], &[&pubinputs[..]]],
-        //         &mut transcript,
-        //     )
-        //     .unwrap();
-        //
-        //     // Write and then read the verification key in between (to check round-trip
-        //     // serialization).
-        //     // TODO: Figure out whether https://github.com/zcash/halo2/issues/449 should
-        //     // be caught by this, or if it is caused by downstream changes to halo2.
-        //     let mut vk_buffer = vec![];
-        //     pk.get_vk().write(&mut vk_buffer).unwrap();
-        //     let vk =
-        //         VerifyingKey::<G1Affine>::read::<_, MyCircuit<Fp>>(&mut &vk_buffer[..], &params)
-        //             .unwrap();
-        //
-        //     // "Second" proof (just the first proof again).
-        //     let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-        //     let strategy = verify_proof(
-        //         &params_verifier,
-        //         &vk,
-        //         strategy,
-        //         &[&[&pubinputs[..]], &[&pubinputs[..]]],
-        //         &mut transcript,
-        //     )
-        //     .unwrap();
-        //
-        //     // Check the batch.
-        //     assert!(strategy.finalize());
-        // }
+        {
+            let strategy = BatchVerifier::new(&params_verifier, OsRng);
+
+            // First proof.
+            let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+            let strategy = verify_proof(
+                &params_verifier,
+                pk.get_vk(),
+                strategy,
+                &[&[&pubinputs[..]], &[&pubinputs[..]]],
+                &mut transcript,
+            )
+            .unwrap();
+
+            // Write and then read the verification key in between (to check round-trip
+            // serialization).
+            // TODO: Figure out whether https://github.com/zcash/halo2/issues/449 should
+            // be caught by this, or if it is caused by downstream changes to halo2.
+            let mut vk_buffer = vec![];
+            pk.get_vk().write(&mut vk_buffer).unwrap();
+            let vk =
+                VerifyingKey::<G1Affine>::read::<_, MyCircuit<Fp>>(&mut &vk_buffer[..], &params)
+                    .unwrap();
+
+            // "Second" proof (just the first proof again).
+            let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+            let strategy = verify_proof(
+                &params_verifier,
+                &vk,
+                strategy,
+                &[&[&pubinputs[..]], &[&pubinputs[..]]],
+                &mut transcript,
+            )
+            .unwrap();
+
+            // Check the batch.
+            assert!(strategy.finalize());
+        }
     }
 }
 */


### PR DESCRIPTION
some dynamic lookup applications only require one-to-one map and  two subsets are full map. currently we can use lookup-any API to fulfill  it, but lookup will involve more constrains checking and calculation.

it would be more efficient to use the shuffle argument which look like this:
                     $$Z(\omega X)\cdot(S(X)+\gamma)-Z(X)\cdot(A(X)+\gamma)$$

thus, the permutation part calculation could be saved.

https://hackmd.io/kR2Ri_seTIipKwdO0cXMGw