### PR TITLE
reduce circuit fix and permutation data

### DIFF
--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -165,7 +165,7 @@ impl<C: CurveAffine> CircuitData<C> {
         let vkey = Self::read_vkey(reader)?;
 
         let fixed = Vec::fetch(reader)?;
-        let permutation = Assembly::vec_fetch(reader)?;
+        let permutation = Assembly::fetch(reader)?;
 
         Ok(CircuitData {
             vkey,
@@ -186,7 +186,7 @@ impl<C: CurveAffine> CircuitData<C> {
         self.vkey.write(fd)?;
 
         self.fixed.store(fd)?;
-        self.permutation.vec_store(fd)?;
+        self.permutation.store(fd)?;
 
         Ok(())
     }


### PR DESCRIPTION
currently  pk circuit data quite large and >5G with k23
fixed data(256bit) occupy >80%
permutation data occupy ~15%

this pr just optimize the datas:
fixed data: only store valid bit 
permutation data: only store permuted cell

after optimization, pk data shrink to ~200M

meanwhile, added parallel processing
 store time reduce to 300ms from 1.3s 
 fetch time reduced to  2s from 2.3s 