### PR TITLE
fix shuffle pinned issue

### DIFF
--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -44,7 +44,7 @@ use std::io;
 
 use self::evaluation::Evaluator;
 use self::permutation::keygen::Assembly;
-
+// use circuit::PinnedForVerifyKey;
 /// This is a verifying key which allows for the verification of proofs for a
 /// particular circuit.
 #[derive(Debug, Clone)]
@@ -117,7 +117,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
             domain: self.domain.pinned(),
             fixed_commitments: &self.fixed_commitments,
             permutation: &self.permutation,
-            cs: self.cs.pinned(),
+            cs: self.cs.pinned().to_string(),
         }
     }
 }
@@ -211,7 +211,7 @@ pub struct PinnedVerificationKey<'a, C: CurveAffine> {
     base_modulus: &'static str,
     scalar_modulus: &'static str,
     domain: PinnedEvaluationDomain<'a, C::Scalar>,
-    cs: PinnedConstraintSystem<'a, C::Scalar>,
+    cs: String,
     fixed_commitments: &'a Vec<C>,
     permutation: &'a permutation::VerifyingKey<C>,
 }

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -1165,10 +1165,10 @@ struct PinnedShuffles<'a, F: Field>(&'a Vec<shuffle::Argument<F>>);
 impl<'a, F: Field> std::fmt::Debug for PinnedShuffles<'a, F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_list()
-            .entries(self.0.iter().enumerate().map(|(i, group)| {
+            .entries(self.0.iter().enumerate().flat_map(|(i, group)| {
                 group.0.iter().enumerate().map(move |(j, arg)| {
                     (
-                        format!("shuffle {}-{}", i, j),
+                        format!("shuffle{}-{}", i, j),
                         &arg.input_expressions,
                         &arg.shuffle_expressions,
                     )


### PR DESCRIPTION
the pinned shuffle takes wrong iterator map method. it result in vkey hash to whole shuffle argumentUnit structure which contains name variable.
if the vkey was write to file and read to vkey again, the shuffle argumentUnit structure will be changed, that is  the name will be set null. so the vkey hash will be changed. and the verification will be fail.

to nested iterator map, the outside map should take flap_map.